### PR TITLE
Add res override, hardcode res select & wine fixes

### DIFF
--- a/inc/main.h
+++ b/inc/main.h
@@ -59,6 +59,8 @@ struct IDirectDrawSurfaceImpl;
 
 extern struct IDirectDrawImpl *ddraw;
 
+extern struct IExtraOpts *extraOpts;
+
 typedef struct SpeedLimiter
 {
     DWORD ticklength;
@@ -67,6 +69,17 @@ typedef struct SpeedLimiter
     LARGE_INTEGER dueTime;
     BOOL useBltOrFlip;
 } SpeedLimiter;
+
+typedef struct IExtraOpts
+{
+    
+    DWORD forcedWidth;
+    DWORD forcedHeight;
+    BOOL hardcodedResolutions;
+
+} IExtraOpts;
+
+
 
 typedef struct IDirectDrawImpl
 {

--- a/src/main.c
+++ b/src/main.c
@@ -495,7 +495,6 @@ HRESULT __stdcall ddraw_EnumDisplayModes(IDirectDrawImpl *This, DWORD dwFlags, L
 		DWORD bpp = 0;
 		DWORD flags = 99998;
 		DWORD fixedOutput = 99998;
-		int res640x480exists = 0;
 		DEVMODE m;
 		memset(&m, 0, sizeof(DEVMODE));
 		m.dmSize = sizeof(DEVMODE);
@@ -503,8 +502,6 @@ HRESULT __stdcall ddraw_EnumDisplayModes(IDirectDrawImpl *This, DWORD dwFlags, L
 		while (EnumDisplaySettings(NULL, i, &m))
 		{
 
-			res640x480exists = res640x480exists || (m.dmPelsWidth == 640 && m.dmPelsHeight == 480);
-			
 			if (refreshRate != 60 && m.dmDisplayFrequency >= 50)
 				refreshRate = m.dmDisplayFrequency;
 
@@ -524,7 +521,7 @@ HRESULT __stdcall ddraw_EnumDisplayModes(IDirectDrawImpl *This, DWORD dwFlags, L
 
 		// Populous hates if 640x480 is not available
 
-		if(!res640x480exists){
+		{
 			// inject 640x480
 
 			memset(&s, 0, sizeof(DDSURFACEDESC));
@@ -537,22 +534,19 @@ HRESULT __stdcall ddraw_EnumDisplayModes(IDirectDrawImpl *This, DWORD dwFlags, L
 			s.ddpfPixelFormat.dwFlags = DDPF_PALETTEINDEXED8 | DDPF_RGB;
 			s.ddpfPixelFormat.dwRGBBitCount = 8;
 
-			if (lpEnumModesCallback(&s, lpContext) == DDENUMRET_CANCEL)
-			{
-				printf("    DDENUMRET_CANCEL returned, stopping\n");
-			}
-			else 
+			
+			if (This->bpp == 16)
 			{
 				s.ddpfPixelFormat.dwFlags = DDPF_RGB;
 				s.ddpfPixelFormat.dwRGBBitCount = 16;
 				s.ddpfPixelFormat.dwRBitMask = 0xF800;
 				s.ddpfPixelFormat.dwGBitMask = 0x07E0;
 				s.ddpfPixelFormat.dwBBitMask = 0x001F;
+			}
 
-				if (lpEnumModesCallback(&s, lpContext) == DDENUMRET_CANCEL)
-				{
-					printf("    DDENUMRET_CANCEL returned, stopping\n");
-				}
+			if (lpEnumModesCallback(&s, lpContext) == DDENUMRET_CANCEL)
+			{
+				printf("    DDENUMRET_CANCEL returned, stopping\n");
 			}
 		}
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -31,6 +31,11 @@ void Settings_Load()
     GetModuleFileNameA(NULL, ProcessFilePath, MAX_PATH);
     _splitpath(ProcessFilePath, NULL, NULL, ProcessFileName, NULL);
 
+    extraOpts->forcedWidth = GetInt("forceResolutionWidth", 0);
+    extraOpts->forcedHeight = GetInt("forceResolutionHeight", 0);
+    extraOpts->hardcodedResolutions = GetBool("hardcodedResolutions", FALSE);
+
+
     //load settings from ini
     ddraw->windowed = GetBool("windowed", FALSE);
     ddraw->border = GetBool("border", TRUE);
@@ -208,7 +213,17 @@ static void CreateSettingsIni()
             "\n"
             "; Stretch to custom resolution, 0 = defaults to the size game requests\n"
             "width=0\n"
-            "height=0\n"
+            "height=0\n" 
+            "\n"
+            "\n"
+            "; Force this to be the only resolution reported besides game-mandatory ones\n"
+            "If used alongside hardcodedResolutions under, it adds the resolution option instead\n"
+            "forceResolutionWidth=0\n"
+            "forceResolutionHeight=0\n"
+            "\n"
+            ";Whether to use the hardcoded resolutions as the reported resolutions to the game\n"
+            "hardcodedResolutions=false\n"
+            "\n"
             "\n"
             "; Override the width/height settings shown above and always stretch to fullscreen\n"
             "; Note: Can be combined with 'windowed=true' to get windowed-fullscreen aka borderless mode\n"


### PR DESCRIPTION
Populous menus fail in many ways if `640x480` is not available, so now I force it to be available even if not reported.

~~Created env vars:
`__CNCDDRAW_HARDCODED_RESOLUTIONS=1`: Whether to use the hardcoded resolutions instead of the provided ones.
`__CNCDDRAW_FORCE_RES_OVERRIDE=1920x1080`: Only register this resolution and `640x480`.~~

Created ini entries:

Force this to be the only resolution reported besides game-mandatory ones
If used alongside hardcodedResolutions under, it adds the resolution option instead
`forceResolutionWidth` + `forceResolutionHeight`

`hardcodedResolutions` Whether to use the hardcoded resolutions as the reported resolutions to the game
            
            

I think windows can also gain from this for Populous use. What do you think?